### PR TITLE
Pybricks BLE Broadcast/Observe documentation updates for v3.3.0

### DIFF
--- a/pybricks-ble-broadcast-observe.md
+++ b/pybricks-ble-broadcast-observe.md
@@ -41,7 +41,7 @@ The data portion of the Manufacturer Specific Data is encoded as follows:
 - This is followed by 0 or more values encoded as follows:
   - A one byte header that indicates the type and size of the value.
     - Types are one of:
-      - `NONE = 0`, the Python `None` value.
+      - `SINGLE_OBJECT = 0`, Indicator that the next value is the one and only value (instead of a tuple).
       - `TRUE = 1`, the Python `True` value.
       - `FALSE = 2`, the Python `False` value.
       - `INT = 3`, the Python `int` type.
@@ -49,7 +49,7 @@ The data portion of the Manufacturer Specific Data is encoded as follows:
       - `STR = 5`, the Python `str` type.
       - `BYTES = 6`, the Python `bytes` type.
     - The length is the number of bytes that follow that contain the value:
-      - For `NONE`, `TRUE`, and `FALSE`, the length is always 0.
+      - For `SINGLE_OBJECT`, `TRUE`, and `FALSE`, the length is always 0.
       - For `INT`, the length is 1 if the value is an 8-bit signed int (-128 to
         127), 2 if the value is a 16-bit signed int (-32768 and 32767) or 4 if
         the value is a 32-bit signed int.
@@ -57,7 +57,7 @@ The data portion of the Manufacturer Specific Data is encoded as follows:
       - For `STR` and `BYTES`, the length can be 0 or greater.
     - The type and length are packed into one byte using `(type << 5) | (length & 0x1F)`.
   - The value encoding depends on the type.
-    - `NONE`, `TRUE`, and `FALSE` have no value.
+    - `SINGLE_OBJECT`, `TRUE`, and `FALSE` have no value.
     - `INT` can be an 8-bit signed int, a 16-bit signed int or a 32-bit signed
       int depending on the given length.
     - `FLOAT` is a 32-bit IEEE 754 floating point value.
@@ -68,6 +68,8 @@ The data portion of the Manufacturer Specific Data is encoded as follows:
     values is limited to 26 bytes.
 
 ### Example payload
+
+Tuple data:
 
 ```
 0x0F, 0xFF, 0x97, 0x03, 0x01, 0x61, 0x64, 0x84, 0x00, 0x00, 0x80, 0x3f, 0xA2, 0x68, 0x69, 0x20
@@ -80,6 +82,25 @@ The data portion of the Manufacturer Specific Data is encoded as follows:
   |     |     |           |     |     |     Header indicating `FLOAT` with length 4
   |     |     |           |     |     `INT` value of 100
   |     |     |           |     Header indicating `INT` with length 1
+  |     |     |           Channel number
+  |     |     LEGO Company Identifier
+  |     Advertising data type indicating Manufacturer Data
+  Length (number of bytes that follow, not including this one)
+```
+
+Single object:
+
+```
+0x07, 0xFF, 0x97, 0x03, 0x01, 0x00, 0x61, 0x64
+  ^     ^     ^     ^     ^     ^     ^     ^
+  |     |     |_____|     |     |     |     |
+  |     |     |           |     |     |     |
+  |     |     |           |     |     |     |
+  |     |     |           |     |     |     |
+  |     |     |           |     |     |     |
+  |     |     |           |     |     |     `INT` value of 100
+  |     |     |           |     |     Header indicating `INT` with length 1
+  |     |     |           |     Header indicating `SINGLE_OBJECT`
   |     |     |           Channel number
   |     |     LEGO Company Identifier
   |     Advertising data type indicating Manufacturer Data


### PR DESCRIPTION
I noticed that the BLE broadcast/observe protocol was changed slightly in [v3.3.0b9](https://github.com/pybricks/pybricks-micropython/releases/tag/v3.3.0b9) but this technical spec was not updated.

If I understand the changes correctly:
- support for the `NONE` type was removed,
- support for the `SINGLE_OBJECT` type was added, which is a flag that indicates that the message only contains a single value instead of the usual list/tuple.

I'm not sure what the original reasoning for the `SINGLE_OBJECT` flag was, as this just seems to reduce the available payload by one byte when a single value is transferred this way as opposed to using a tuple. For this pull request, I've simply taken the comment from the reference implementation to describe this type, however you might be able to rephrase this and include a better explanation.